### PR TITLE
Update the endpoint for custom fields addition and add option to allow custom fields with non-ascii characters

### DIFF
--- a/contrib/ManageConfig/submit_config.py
+++ b/contrib/ManageConfig/submit_config.py
@@ -34,15 +34,19 @@ def insert_case_templates(thehive_url, api_key, case_templates):
             raise Exception("{} : {}".format(response.status_code, response.text))
 
 
-def insert_custom_fields(thehive_url, api_key, custom_fields):
+def insert_custom_fields(thehive_url, api_key, custom_fields, utf_json):
     for cf in custom_fields:
-        response = requests.post('{}/api/list/custom_fields'.format(thehive_url),
-                                 headers={"Authorization": "Bearer {}".format(api_key),
-                                          'Content-Type': 'application/json'},
-                                 data=json.dumps({"value": cf}))
+        response = requests.post(
+            '{}/api/customField'.format(thehive_url),
+            headers={
+                "Authorization": "Bearer {}".format(api_key),
+                'Content-Type': 'application/json'
+            },
+            data=json.dumps(cf, ensure_ascii=not utf_json)
+        )
         if response.status_code == 400:
             print(response.text)
-        elif response.status_code != 200:
+        elif response.status_code != 201:
             raise Exception("{} : {}".format(response.status_code, response.text))
 
 
@@ -58,13 +62,13 @@ def insert_metrics(thehive_url, api_key, metrics):
             raise Exception("{} : {}".format(response.status_code, response.text))
 
 
-def submit_config(thehive_url, api_key, conf_path):
+def submit_config(thehive_url, api_key, conf_path, utf_json):
     with open(conf_path, 'r') as infile:
         config = json.loads(infile.read())
         print("Inserting observable  datatypes...")
         insert_datatypes(thehive_url, api_key, config["datatypes"])
         print("Inserting custom fields...")
-        insert_custom_fields(thehive_url, api_key, config["custom_fields"])
+        insert_custom_fields(thehive_url, api_key, config["custom_fields"], utf_json)
         print("Inserting metrics...")
         insert_metrics(thehive_url, api_key, config["metrics"])
         print("Inserting case templates...")
@@ -78,13 +82,19 @@ def parse_args():
         help=("TheHive server url."),required=True)
     parser.add_argument("-c", "--config_path",
                         help=("Configuration file path."), required=True)
+    parser.add_argument(
+        '--utf-json', 
+        dest='utf_json',
+        help='Do not force ASCII decoding of the configuration file (only for custom fields)',
+        action=argparse.BooleanOptionalAction
+    )
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
     print("Submitting config to  {}".format(args.url))
-    submit_config(args.url, args.key, args.config_path)
+    submit_config(args.url, args.key, args.config_path, args.utf_json)
 
 
 if __name__ == "__main__" :


### PR DESCRIPTION
The endpoint /api/customField is used on newer versions of TheHive to add custom fields. Also, to add custom fields that have non-ascii characters, the option ensure_ascii on json.dumps needs to be set to False (it is True by default).
